### PR TITLE
docs(WPI-40): add plan-mode prompt and condense planning section

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,16 +12,12 @@ Audience & Usage
 
 ## 1) Plan Before You Code (required)
 
-Before starting any implementation:
-- Define the problem, scope, and Acceptance Criteria in Jira (link Confluence when applicable).
-- Identify risks/assumptions and how you’ll validate them.
-- Decide minimal tests you’ll write/run to prove it works.
-- Create a feature branch from up‑to‑date `main` (see Section 3 and 4).
+Non‑trivial implementation work requires a plan file first. Enter **PLAN MODE** using the prompt at `.github/prompts/plan-mode.md` (paste into Copilot Chat or invoke a custom mode) and generate `docs/plans/NN-TitleCaseSubject.md` with the required sections. Only after that plan is committed should code be written; reference the plan in your PR. Agents must decline substantive code generation if no plan file is referenced.
 
-Completion gate for planning:
-- [ ] Jira ticket has a clear Description and AC
-- [ ] Links to any docs/specs
-- [ ] Validation approach noted (tests + manual checks)
+Planning completion gate:
+- [ ] Jira ticket has clear Description + AC
+- [ ] Plan file exists in `docs/plans/` (all required sections filled)
+- [ ] Validation (tests + manual) noted & linked
 
 ---
 

--- a/.github/prompts/plan-mode.md
+++ b/.github/prompts/plan-mode.md
@@ -1,0 +1,32 @@
+# PLAN MODE (Repository Planning Prompt)
+
+You are in PLAN MODE. Do NOT generate implementation code yet.
+
+Goal: Produce a new plan markdown file ONLY (no meta commentary) to be stored in `docs/plans/`.
+
+If scope or acceptance criteria are unclear: ask clarifying questions FIRST, then wait.
+
+## Required Sections (in this order)
+1. Problem
+2. Scope (In / Out)
+3. Acceptance Criteria (explicit, testable checklist)
+4. Risks & Assumptions + Validation (table)
+5. Minimal Tests (unit / integration / manual)
+6. Task Breakdown (checkbox list, include tests & docs tasks)
+7. Links (Jira, Confluence, future PR)
+8. Review Sign-off (table)
+
+## Naming
+Plan filename: `NN-TitleCaseSubject.md` where NN is the next sequential number (zero‑padded). If user has not supplied NN yet, begin file with `# NN-TitleCaseSubject` and indicate TODO to set number.
+
+## Rules
+- Output ONLY the markdown for the plan (begin with `# NN-Title...`).
+- No implementation code or large code blocks (unless tiny snippet clarifies a test idea).
+- Tasks must be atomic (1–2 verbs). Include tasks for tests, docs, PR.
+- Mark gaps with `TODO:` lines instead of inventing details.
+- Refuse to switch to implementation until a saved plan filename is referenced by the user.
+
+## Example Invocation (user side)
+"Plan for WPI-123: Add user management (create, list, basic auth). Next number likely 03."
+
+Respond with the filled template only.


### PR DESCRIPTION
## What does this PR do?

*   **Related Issue:** Closes WPI-40
*   Adds planning prompt file (.github/prompts/plan-mode.md) and updates Section 1 of [copilot-instructions.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to enforce plan-before-code.

Changes:

Added [plan-mode.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated [copilot-instructions.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Section 1 only)
Validation:

Invoked via hash reference (# .github/prompts/plan-mode.md) successfully; agent generated numbered plan
Jira WPI-40 commented with completion summary
Confluence doc (ID 36601858) published
Diff limited to two files (docs only)
Risk: Low (documentation only)

---

### Simple Checklist

- [x] I have tested my changes locally and/or on the Preview URL.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation if necessary.
